### PR TITLE
[codex] improve evidence-based engineering index guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,3 +55,9 @@ order: 0
 - [ケーススタディ](appendices/case-studies/)
 - [チェックリスト集](appendices/checklists/)
 - [参考文献](appendices/references/)
+
+## 利用と更新情報
+
+- ライセンス: CC BY-NC-SA 4.0（商用利用は別契約）
+- リポジトリ: [itdojp/evidence-based-engineering-book](https://github.com/itdojp/evidence-based-engineering-book)
+- 更新差分を追う場合は、GitHub のコミット履歴と Pull Request を参照する

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ order: 0
 
 ## 利用と更新情報
 
-- ライセンス: CC BY-NC-SA 4.0（商用利用は別契約）
+- ライセンス: [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja)（このライセンスでは商用利用は許諾されないため、商用利用は別途許諾が必要）
+- 詳細なライセンス条件: [LICENSE.md](https://github.com/itdojp/evidence-based-engineering-book/blob/main/LICENSE.md)
 - リポジトリ: [itdojp/evidence-based-engineering-book](https://github.com/itdojp/evidence-based-engineering-book)
-- 更新差分を追う場合は、GitHub のコミット履歴と Pull Request を参照する
+- 更新差分を追う場合は、GitHub の [コミット履歴](https://github.com/itdojp/evidence-based-engineering-book/commits/main/) と [PR 一覧](https://github.com/itdojp/evidence-based-engineering-book/pulls) を参照する


### PR DESCRIPTION
## What changed
- added a `利用と更新情報` section to `docs/index.md`
- clarified the license note and linked the repository as the update source
- directed readers to GitHub commit and PR history for update tracking

## Why
- the top page needed a clearer reader-facing update path without changing the appendix structure

## Validation
- `git diff --check`
- `node ../book-formatter/scripts/check-links.js docs`
- `node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error`