### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## Summary
- Book QAとCIの`actions/setup-node`を`v4`からNode.js 24 runtime対応の`v6`へ更新
- `node-version: '20'`、npm cache、実行コマンド、permissionsは維持
- active workflow内の対象旧参照を0件化

## Verification
- actionlint 1.7.12（変更2 workflow）: PASS
- `npm ci`: PASS
- `npm test`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS
- 旧`setup-node@v4`: 0 / 新`setup-node@v6`: 2

## Separated debt
- `npm audit`の既存5件（moderate 3 / high 2）は依存更新の変更所有権を分離し、#33で追跡

Closes #32
