### PR TITLE
docs: 検索演算子を公式ソースへ紐づける

### DIFF
--- a/docs/appendices/references/index.md
+++ b/docs/appendices/references/index.md
@@ -17,9 +17,15 @@ order: 920
 ## Git / GitHub（一次情報）
 
 - [Git documentation](https://git-scm.com/docs)
-- [GitHub Docs: Searching on GitHub](https://docs.github.com/en/search-github/searching-on-github)
-- [GitHub Docs: About code search](https://docs.github.com/en/search-github/github-code-search/about-github-code-search)
+- [GitHub Docs: Understanding GitHub Code Search syntax](https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax)
+- [GitHub Docs: Filtering and searching issues and pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests)
 - [GitHub Docs: About pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-pull-requests)
+
+## 一般検索（一次情報）
+
+- [Google 検索ヘルプ: ウェブ検索の結果を絞り込む](https://support.google.com/websearch/answer/2466433?co=GENIE.Platform%3DDesktop&hl=ja&rd=1)
+- [Microsoft Support: Advanced search keywords](https://support.microsoft.com/en-US/bing/advanced-search-keywords)
+- [Microsoft Support: Advanced search options](https://support.microsoft.com/en-US/bing/advanced-search-options)
 
 ## 検証/再現性
 

--- a/docs/chapters/chapter-02/index.md
+++ b/docs/chapters/chapter-02/index.md
@@ -43,10 +43,22 @@ order: 20
 
 同じ見た目のクエリでも、検索先によって「有効な検索演算子」「ヒットする対象」が異なる。クエリ例には「適用先（一般検索/GitHub検索）」を明示する。
 
-- 一般検索（Google/Bing など）: `site:` `-keyword` `OR` `""` などが有効
-- GitHub検索（Code/Issue/PR）: `repo:` `path:` `language:` `symbol:` `is:issue` などが有効
+- Google 検索: 完全一致の `"..."`、除外の `-keyword`、サイト指定の `site:` は
+  [Google 検索ヘルプ「ウェブ検索の結果を絞り込む」](https://support.google.com/websearch/answer/2466433?co=GENIE.Platform%3DDesktop&hl=ja&rd=1)
+  で確認する。演算子と検索語の間には空白を入れない。
+- Bing 検索: `site:` は
+  [Microsoft Support「Advanced search keywords」](https://support.microsoft.com/en-US/bing/advanced-search-keywords)、
+  完全一致の `"..."`、除外の `-keyword`、論理和の `OR` は
+  [Microsoft Support「Advanced search options」](https://support.microsoft.com/en-US/bing/advanced-search-options)
+  で確認する。`OR` と `NOT` は大文字で記述し、`site:` のコロンの後には空白を入れない。
+- GitHub コード検索: `repo:` `path:` `language:` `symbol:` は
+  [GitHub Docs「Understanding GitHub Code Search syntax」](https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax)
+  で確認する。
+- GitHub Issue/PR 検索: `repo:` `is:issue` `is:pr` は
+  [GitHub Docs「Filtering and searching issues and pull requests」](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests)
+  で確認する。コード検索の構文資料とは参照先が異なる。
 
-注意: 検索演算子や挙動は提供側の仕様変更で変わりうる。最終的には一次情報（公式ドキュメント）で要確認とする。
+注意: 上記は 2026-07-21 JST に確認した情報である。検索演算子の仕様や提供地域は変更される可能性があるため、利用時点の各提供者の公式ドキュメントを正本とする。
 
 ### 検索先 × 目的（対応表）
 
@@ -91,7 +103,7 @@ order: 20
 絞り込み（前提固定）: libraryX "v2.3" -windows
 一次情報へ（一般検索）: site:docs.example.com timeout / site:github.com libraryX timeout default
 一次情報へ（GitHub検索）: repo:org/libraryX path:src timeout default
-次善策（一般検索）: site:github.com libraryX "timeout" "default" (issue OR pull)
+次善策（一般検索/Bing）: site:github.com libraryX "timeout" "default" (issue OR pull)
 結果: 公式ドキュメント + 該当コミット + 再現ログまで到達し、前提/例外をメモした
 ```
 


### PR DESCRIPTION
## 概要

- Google と Bing の一般検索演算子を提供者別に整理し、各公式ヘルプへ直接リンク
- GitHub Code Search と Issue/PR Search の構文・出典を分離
- 確認日、仕様・提供地域が変わりうる注意、公式資料を正本とする契約を明記
- 付録参考文献を本文と同一の一次情報URLへ整合

Closes #35

## 検証

- `mise exec node@24 -- npm ci`
- `mise exec node@24 -- npm test`
- `mise exec node@24 -- npm run build`
- book-formatter `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`
  - Unicode: 0件
  - Markdown structure: 0件
  - Layout risk: 0件
  - textlint: 0件
- 生成ページ `/chapters/chapter-02/` と `/appendices/references/`: HTTP 200、5つの公式参照と注記の文脈を確認

## スコープ分離

依存脆弱性（#33）およびAI調査ログ（#36）は本PRに含めていません。`npm ci` が報告する既知の5件は #33 で追跡されています。
